### PR TITLE
changed Imports to pass Travis CI

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: strataG
 Title: Summaries and Population Structure Analyses of Genetic Data
 Description: A toolkit for analyzing stratified population genetic data.
-Version: 2.0.0
+Version: 2.0.1
 License: GNU General Public License
 Authors@R: c(
   EA = person("Eric", "Archer", email = "eric.archer@noaa.gov", role = c("aut", "cre")),
@@ -34,6 +34,7 @@ Imports:
     shiny,
     shinyFiles,
     stats,
+    survival (>= 2.40.1),
     swfscMisc,
     utils
 Collate:


### PR DESCRIPTION
* `survival` (>= 2.40.1) added to pass Travis build that require at least this version number for Hmisc
* bumped strataG version to reflect change