### PR TITLE
Update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,33 @@
 
 ## Installation
 
-To install the stable version from CRAN:
+To install the stable version using install.packages requires an extra
+repo to be made available to the install.packages function prior to
+install as the strataG is not available via CRAN:
 
 ```r
+
+options(repos = c(
+            zkamvar = 'https://zkamvar.r-universe.dev',
+            CRAN = 'https://cloud.r-project.org'))
+
 install.packages('strataG')
 ```
 
-To install the latest version from GitHub:
+NB! Make sure that you have installed the development version of the
+dependency [sprex](https://github.com/EricArcher/sprex) prior to
+installing strataG
+
+
+To install the latest version from GitHub including the development
+version of sprex:
 
 ```r
 # make sure you have Rtools installed
 if (!require('devtools')) install.packages('devtools')
-# install from GitHub
+# install sprex development version
+devtools::install_github("ericarcher/sprex")
+# install strataG latest version
 devtools::install_github('ericarcher/strataG', build_vignettes = TRUE)
 ```
 


### PR DESCRIPTION
Had some issues installing strataG with the instructions in the README.md. The package does not seem to be available on CRAN anymore and trying to get it from other repos worked, but meant that I ended up with a version that required at least version 1.4.2 of sprex and the latest on CRAN is 1.4.1. The install instructions using devtools also failed as building the vignette needs version 1.4.2 of sprex. New instructions put emphasis on getting the correct version of sprex prior to installing strataG
